### PR TITLE
Message is published twice in some cases

### DIFF
--- a/src/RabbitMq/Producer/DatabaseTransactionProducer.php
+++ b/src/RabbitMq/Producer/DatabaseTransactionProducer.php
@@ -34,11 +34,12 @@ class DatabaseTransactionProducer implements \OldSound\RabbitMqBundle\RabbitMq\P
 	{
 		if (!$this->databaseConnection->isTransactionActive()) {
 			$this->wrappedProducer->publish($messageBody, $routingKey, $additionalProperties);
-		}
+		} else {
 
-		$this->databaseConnection->addAfterCommitCallback(function () use ($messageBody, $routingKey, $additionalProperties) {
-			$this->wrappedProducer->publish($messageBody, $routingKey, $additionalProperties);
-		});
+			$this->databaseConnection->addAfterCommitCallback(function () use ($messageBody, $routingKey, $additionalProperties) {
+				$this->wrappedProducer->publish($messageBody, $routingKey, $additionalProperties);
+			});
+		}
 	}
 
 }


### PR DESCRIPTION
Hi Vašek,

I don't really want you to merge this test without any further investigation and at least squashing the commits and adding more test cases; because this pull request is meant to be a better issue report :-)

We have examined this bundle and found out that I contains a serious issue. If you publish two messages in one execution, the first one would be published twice.

1. if you publish message immediately you also stack the same call into the afterCommitCallbacks array in Connection.
2. by publishing a second message in transaction, you also fire all the callbacks that are stacked in the array; so you publish message 2 + message 1 again.

Possible solution: stack the first message into array only if it is not sent immediately: https://github.com/tuscanicz/Rabbit-Mq-Database-Transaction-Producer-Bundle/commit/f4edfd1152480afbf5d25cfe157049de27130dd1

However, we did not test the solution, because we have refactored your RabbitMQ implementation and also removed the rabbitmq bundle. We fire TransactionCommitedEvent and handle it quite different, so the resolution is not tested.