### PR TITLE
Refactor tests

### DIFF
--- a/tests/DependencyInjection/RabbitMqDatabaseTransactionProducerExtensionTest.php
+++ b/tests/DependencyInjection/RabbitMqDatabaseTransactionProducerExtensionTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace VasekPurchart\RabbitMqDatabaseTransactionProducerBundle\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
+use Generator;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -52,27 +53,46 @@ class RabbitMqDatabaseTransactionProducerExtensionTest extends \Matthias\Symfony
 		Assert::assertSame(Connection::class, $doctrineConfig[0]['dbal']['wrapper_class']);
 	}
 
-	public function testLoadExtension(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function configureContainerParameterDataProvider(): Generator
 	{
-		$this->loadExtensions();
+		yield 'default connection integration' => [
+			'configuration' => [],
+			'parameterName' => RabbitMqDatabaseTransactionProducerExtension::CONTAINER_PARAMETER_CUSTOM_CONNECTION_CLASS,
+			'expectedParameterValue' => false,
+		];
 
-		$this->assertContainerBuilderHasParameter(
-			RabbitMqDatabaseTransactionProducerExtension::CONTAINER_PARAMETER_CUSTOM_CONNECTION_CLASS,
-			false
-		);
+		yield 'turn off default connection integration' => [
+			'configuration' => [
+				'rabbit_mq_database_transaction_producer' => [
+					'custom_connection_class' => true,
+				],
+			],
+			'parameterName' => RabbitMqDatabaseTransactionProducerExtension::CONTAINER_PARAMETER_CUSTOM_CONNECTION_CLASS,
+			'expectedParameterValue' => true,
+		];
 	}
 
-	public function testTurnOffDefaultConnectionIntegration(): void
+	/**
+	 * @dataProvider configureContainerParameterDataProvider
+	 *
+	 * @param mixed[][] $configuration
+	 * @param string $parameterName
+	 * @param bool $expectedParameterValue
+	 */
+	public function testConfigureContainerParameter(
+		array $configuration,
+		string $parameterName,
+		bool $expectedParameterValue
+	): void
 	{
-		$this->loadExtensions([
-			'rabbit_mq_database_transaction_producer' => [
-				'custom_connection_class' => true,
-			],
-		]);
+		$this->loadExtensions($configuration);
 
 		$this->assertContainerBuilderHasParameter(
-			RabbitMqDatabaseTransactionProducerExtension::CONTAINER_PARAMETER_CUSTOM_CONNECTION_CLASS,
-			true
+			$parameterName,
+			$expectedParameterValue
 		);
 	}
 

--- a/tests/DependencyInjection/RabbitMqDatabaseTransactionProducerExtensionTest.php
+++ b/tests/DependencyInjection/RabbitMqDatabaseTransactionProducerExtensionTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace VasekPurchart\RabbitMqDatabaseTransactionProducerBundle\DependencyInjection;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
+use PHPUnit\Framework\Assert;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use VasekPurchart\RabbitMqDatabaseTransactionProducerBundle\Doctrine\Connection\Connection;
@@ -45,10 +46,10 @@ class RabbitMqDatabaseTransactionProducerExtensionTest extends \Matthias\Symfony
 
 		$doctrineConfig = $this->container->getExtensionConfig('doctrine');
 		if (!isset($doctrineConfig[0]) || !isset($doctrineConfig[0]['dbal']) || !isset($doctrineConfig[0]['dbal']['wrapper_class'])) {
-			$this->fail();
+			Assert::fail();
 		}
 
-		$this->assertSame(Connection::class, $doctrineConfig[0]['dbal']['wrapper_class']);
+		Assert::assertSame(Connection::class, $doctrineConfig[0]['dbal']['wrapper_class']);
 	}
 
 	public function testLoadExtension(): void

--- a/tests/Doctrine/Connection/ConnectionCompilerPassTest.php
+++ b/tests/Doctrine/Connection/ConnectionCompilerPassTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace VasekPurchart\RabbitMqDatabaseTransactionProducerBundle\Doctrine\Connection;
 
+use PHPUnit\Framework\Assert;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -38,9 +39,9 @@ class ConnectionCompilerPassTest extends \Matthias\SymfonyDependencyInjectionTes
 		$setLoggerCall = $this->container->findDefinition(
 			RabbitMqDatabaseTransactionProducerExtension::CONTAINER_SERVICE_DATABASE_CONNECTION
 		)->getMethodCalls()[0];
-		$this->assertSame('setLogger', $setLoggerCall[0]);
-		$this->assertInstanceOf(Reference::class, $setLoggerCall[1][0]);
-		$this->assertSame(
+		Assert::assertSame('setLogger', $setLoggerCall[0]);
+		Assert::assertInstanceOf(Reference::class, $setLoggerCall[1][0]);
+		Assert::assertSame(
 			RabbitMqDatabaseTransactionProducerExtension::CONTAINER_SERVICE_LOGGER,
 			$setLoggerCall[1][0]->__toString()
 		);
@@ -68,7 +69,7 @@ class ConnectionCompilerPassTest extends \Matthias\SymfonyDependencyInjectionTes
 			RabbitMqDatabaseTransactionProducerExtension::CONTAINER_SERVICE_DATABASE_CONNECTION
 		)->getMethodCalls();
 		foreach ($methodCalls as $methodCall) {
-			$this->assertNotSame('setLogger', $methodCall[0]);
+			Assert::assertNotSame('setLogger', $methodCall[0]);
 		}
 	}
 

--- a/tests/Doctrine/Connection/ConnectionTest.php
+++ b/tests/Doctrine/Connection/ConnectionTest.php
@@ -218,7 +218,7 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 			$mock->callback1();
 		});
 
-		Assert::fail();
+		Assert::fail('Exception expected');
 	}
 
 	public function testSetLoggerOnlyOnce(): void

--- a/tests/Doctrine/Connection/ConnectionTest.php
+++ b/tests/Doctrine/Connection/ConnectionTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace VasekPurchart\RabbitMqDatabaseTransactionProducerBundle\Doctrine\Connection;
 
 use Doctrine\DBAL\Driver\PDO\SQLite\Driver as PDOSqliteDriver;
+use PHPUnit\Framework\Assert;
 use Psr\Log\LoggerInterface;
 
 class ConnectionTest extends \PHPUnit\Framework\TestCase
@@ -16,13 +17,13 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 
 		$loggerMock = $this->createMock(LoggerInterface::class);
 		$loggerMock
-			->expects($this->never())
+			->expects(self::never())
 			->method('error');
 		$connection->setLogger($loggerMock);
 
 		$mock = $this->createMock(DummyCallbacks::class);
 		$mock
-			->expects($this->once())
+			->expects(self::once())
 			->method('callback1');
 
 		$connection->addAfterCommitCallback(function () use ($mock): void {
@@ -44,13 +45,13 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 
 		$loggerMock = $this->createMock(LoggerInterface::class);
 		$loggerMock
-			->expects($this->never())
+			->expects(self::never())
 			->method('error');
 		$connection->setLogger($loggerMock);
 
 		$mock = $this->createMock(DummyCallbacks::class);
 		$mock
-			->expects($this->never())
+			->expects(self::never())
 			->method('callback1');
 
 		$connection->addAfterCommitCallback(function () use ($mock): void {
@@ -72,16 +73,16 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 
 		$loggerMock = $this->createMock(LoggerInterface::class);
 		$loggerMock
-			->expects($this->never())
+			->expects(self::never())
 			->method('error');
 		$connection->setLogger($loggerMock);
 
 		$mock = $this->createMock(DummyCallbacks::class);
 		$mock
-			->expects($this->once())
+			->expects(self::once())
 			->method('callback1');
 		$mock
-			->expects($this->once())
+			->expects(self::once())
 			->method('callback2');
 
 		$connection->addAfterCommitCallback(function () use ($mock): void {
@@ -106,16 +107,16 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 
 		$loggerMock = $this->createMock(LoggerInterface::class);
 		$loggerMock
-			->expects($this->never())
+			->expects(self::never())
 			->method('error');
 		$connection->setLogger($loggerMock);
 
 		$mock = $this->createMock(DummyCallbacks::class);
 		$mock
-			->expects($this->never())
+			->expects(self::never())
 			->method('callback1');
 		$mock
-			->expects($this->never())
+			->expects(self::never())
 			->method('callback2');
 
 		$connection->addAfterCommitCallback(function () use ($mock): void {
@@ -140,13 +141,13 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 
 		$loggerMock = $this->createMock(LoggerInterface::class);
 		$loggerMock
-			->expects($this->never())
+			->expects(self::never())
 			->method('error');
 		$connection->setLogger($loggerMock);
 
 		$mock = $this->createMock(DummyCallbacks::class);
 		$mock
-			->expects($this->never())
+			->expects(self::never())
 			->method('callback1');
 
 		$connection->addAfterCommitCallback(function () use ($mock): void {
@@ -160,14 +161,14 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 		$connection->beginTransaction();
 		$connection->rollBack();
 
-		$this->assertTrue($connection->isRollbackOnly());
+		Assert::assertTrue($connection->isRollbackOnly());
 
 		// outer transaction
 		$connection->rollBack();
 
 		// callbacks should be already cleared
 		$connection->beginTransaction();
-		$this->assertFalse($connection->isRollbackOnly());
+		Assert::assertFalse($connection->isRollbackOnly());
 		$connection->commit();
 	}
 
@@ -177,13 +178,13 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 
 		$loggerMock = $this->createMock(LoggerInterface::class);
 		$loggerMock
-			->expects($this->once())
+			->expects(self::once())
 			->method('error')
 			->with(
-				$this->callback(function ($message): bool {
+				Assert::callback(function ($message): bool {
 					return strpos($message, 'callback failed') !== false;
 				}),
-				$this->callback(function ($data): bool {
+				Assert::callback(function ($data): bool {
 					return ($data['exception'] instanceof \Exception)
 						&& $data['exception']->getMessage() === 'callback failed';
 				})
@@ -197,7 +198,7 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 		$connection->beginTransaction();
 		$connection->commit();
 
-		$this->assertTrue(true, 'callback exception was properly caught');
+		Assert::assertTrue(true, 'callback exception was properly caught');
 	}
 
 	public function testMissingLogger(): void
@@ -206,7 +207,7 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 
 		$mock = $this->createMock(DummyCallbacks::class);
 		$mock
-			->expects($this->never())
+			->expects(self::never())
 			->method('callback1');
 
 		$this->expectException(
@@ -217,7 +218,7 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 			$mock->callback1();
 		});
 
-		$this->fail();
+		Assert::fail();
 	}
 
 	public function testSetLoggerOnlyOnce(): void
@@ -226,7 +227,7 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 
 		$loggerMock = $this->createMock(LoggerInterface::class);
 		$loggerMock
-			->expects($this->never())
+			->expects(self::never())
 			->method('error');
 		$connection->setLogger($loggerMock);
 

--- a/tests/Doctrine/Connection/ConnectionTest.php
+++ b/tests/Doctrine/Connection/ConnectionTest.php
@@ -14,13 +14,13 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 	{
 		$connection = $this->getConnection();
 
-		$loggerMock = $this->getLoggerMock();
+		$loggerMock = $this->createMock(LoggerInterface::class);
 		$loggerMock
 			->expects($this->never())
 			->method('error');
 		$connection->setLogger($loggerMock);
 
-		$mock = $this->getCallbacksMock();
+		$mock = $this->createMock(DummyCallbacks::class);
 		$mock
 			->expects($this->once())
 			->method('callback1');
@@ -42,13 +42,13 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 	{
 		$connection = $this->getConnection();
 
-		$loggerMock = $this->getLoggerMock();
+		$loggerMock = $this->createMock(LoggerInterface::class);
 		$loggerMock
 			->expects($this->never())
 			->method('error');
 		$connection->setLogger($loggerMock);
 
-		$mock = $this->getCallbacksMock();
+		$mock = $this->createMock(DummyCallbacks::class);
 		$mock
 			->expects($this->never())
 			->method('callback1');
@@ -70,13 +70,13 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 	{
 		$connection = $this->getConnection();
 
-		$loggerMock = $this->getLoggerMock();
+		$loggerMock = $this->createMock(LoggerInterface::class);
 		$loggerMock
 			->expects($this->never())
 			->method('error');
 		$connection->setLogger($loggerMock);
 
-		$mock = $this->getCallbacksMock();
+		$mock = $this->createMock(DummyCallbacks::class);
 		$mock
 			->expects($this->once())
 			->method('callback1');
@@ -104,13 +104,13 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 	{
 		$connection = $this->getConnection();
 
-		$loggerMock = $this->getLoggerMock();
+		$loggerMock = $this->createMock(LoggerInterface::class);
 		$loggerMock
 			->expects($this->never())
 			->method('error');
 		$connection->setLogger($loggerMock);
 
-		$mock = $this->getCallbacksMock();
+		$mock = $this->createMock(DummyCallbacks::class);
 		$mock
 			->expects($this->never())
 			->method('callback1');
@@ -138,13 +138,13 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 	{
 		$connection = $this->getConnection();
 
-		$loggerMock = $this->getLoggerMock();
+		$loggerMock = $this->createMock(LoggerInterface::class);
 		$loggerMock
 			->expects($this->never())
 			->method('error');
 		$connection->setLogger($loggerMock);
 
-		$mock = $this->getCallbacksMock();
+		$mock = $this->createMock(DummyCallbacks::class);
 		$mock
 			->expects($this->never())
 			->method('callback1');
@@ -175,7 +175,7 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 	{
 		$connection = $this->getConnection();
 
-		$loggerMock = $this->getLoggerMock();
+		$loggerMock = $this->createMock(LoggerInterface::class);
 		$loggerMock
 			->expects($this->once())
 			->method('error')
@@ -204,7 +204,7 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 	{
 		$connection = $this->getConnection();
 
-		$mock = $this->getCallbacksMock();
+		$mock = $this->createMock(DummyCallbacks::class);
 		$mock
 			->expects($this->never())
 			->method('callback1');
@@ -224,7 +224,7 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 	{
 		$connection = $this->getConnection();
 
-		$loggerMock = $this->getLoggerMock();
+		$loggerMock = $this->createMock(LoggerInterface::class);
 		$loggerMock
 			->expects($this->never())
 			->method('error');
@@ -240,22 +240,6 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
 	private function getConnection(): Connection
 	{
 		return new Connection(['path' => ':memory:'], new PDOSqliteDriver());
-	}
-
-	/**
-	 * @return \VasekPurchart\RabbitMqDatabaseTransactionProducerBundle\Doctrine\Connection\DummyCallbacks|\PHPUnit_Framework_MockObject_MockObject
-	 */
-	private function getCallbacksMock(): DummyCallbacks
-	{
-		return $this->createMock(DummyCallbacks::class);
-	}
-
-	/**
-	 * @return \Psr\Log\LoggerInterface|\PHPUnit_Framework_MockObject_MockObject
-	 */
-	private function getLoggerMock(): LoggerInterface
-	{
-		return $this->createMock(LoggerInterface::class);
 	}
 
 }

--- a/tests/RabbitMq/Producer/DatabaseTransactionProducerIntegrationTest.php
+++ b/tests/RabbitMq/Producer/DatabaseTransactionProducerIntegrationTest.php
@@ -6,6 +6,7 @@ namespace VasekPurchart\RabbitMqDatabaseTransactionProducerBundle\RabbitMq\Produ
 
 use Doctrine\Bundle\DoctrineBundle\ConnectionFactory;
 use OldSound\RabbitMqBundle\RabbitMq\Producer;
+use PHPUnit\Framework\Assert;
 use Psr\Log\LoggerInterface;
 use VasekPurchart\RabbitMqDatabaseTransactionProducerBundle\Doctrine\Connection\Connection;
 
@@ -24,9 +25,9 @@ class DatabaseTransactionProducerIntegrationTest extends \PHPUnit\Framework\Test
 			->disableOriginalConstructor()
 			->getMock();
 		$originalProducer
-			->expects($this->once())
+			->expects(self::once())
 			->method('publish')
-			->with($this->callback(function ($receivedMessage) use ($message, &$wasAlreadyPublished) {
+			->with(Assert::callback(function ($receivedMessage) use ($message, &$wasAlreadyPublished) {
 				$wasAlreadyPublished = true;
 
 				return $receivedMessage === $message;
@@ -35,9 +36,9 @@ class DatabaseTransactionProducerIntegrationTest extends \PHPUnit\Framework\Test
 		$databaseTransactionProducer = new DatabaseTransactionProducer($originalProducer, $connection);
 
 		$connection->query('SELECT 1');
-		$this->assertFalse($wasAlreadyPublished);
+		Assert::assertFalse($wasAlreadyPublished);
 		$databaseTransactionProducer->publish($message);
-		$this->assertTrue($wasAlreadyPublished);
+		Assert::assertTrue($wasAlreadyPublished);
 	}
 
 	public function testMessageIsSentAfterTransaction(): void
@@ -52,9 +53,9 @@ class DatabaseTransactionProducerIntegrationTest extends \PHPUnit\Framework\Test
 			->disableOriginalConstructor()
 			->getMock();
 		$originalProducer
-			->expects($this->once())
+			->expects(self::once())
 			->method('publish')
-			->with($this->callback(function ($receivedMessage) use ($message, &$wasAlreadyPublished) {
+			->with(Assert::callback(function ($receivedMessage) use ($message, &$wasAlreadyPublished) {
 				$wasAlreadyPublished = true;
 
 				return $receivedMessage === $message;
@@ -70,11 +71,11 @@ class DatabaseTransactionProducerIntegrationTest extends \PHPUnit\Framework\Test
 			&$wasAlreadyPublished
 		): void {
 			$connection->query('SELECT 1');
-			$this->assertFalse($wasAlreadyPublished);
+			Assert::assertFalse($wasAlreadyPublished);
 			$databaseTransactionProducer->publish($message);
-			$this->assertFalse($wasAlreadyPublished);
+			Assert::assertFalse($wasAlreadyPublished);
 		});
-		$this->assertTrue($wasAlreadyPublished);
+		Assert::assertTrue($wasAlreadyPublished);
 	}
 
 	public function testMessageIsNeverSentIfTransactionIsNotCompleted(): void
@@ -88,7 +89,7 @@ class DatabaseTransactionProducerIntegrationTest extends \PHPUnit\Framework\Test
 			->disableOriginalConstructor()
 			->getMock();
 		$originalProducer
-			->expects($this->never())
+			->expects(self::never())
 			->method('publish');
 
 		$databaseTransactionProducer = new DatabaseTransactionProducer($originalProducer, $connection);
@@ -110,9 +111,9 @@ class DatabaseTransactionProducerIntegrationTest extends \PHPUnit\Framework\Test
 			->disableOriginalConstructor()
 			->getMock();
 		$originalProducer
-			->expects($this->once())
+			->expects(self::once())
 			->method('publish')
-			->with($this->callback(function ($receivedMessage) use ($message, &$wasAlreadyPublished) {
+			->with(Assert::callback(function ($receivedMessage) use ($message, &$wasAlreadyPublished) {
 				$wasAlreadyPublished = true;
 
 				return $receivedMessage === $message;
@@ -122,14 +123,14 @@ class DatabaseTransactionProducerIntegrationTest extends \PHPUnit\Framework\Test
 
 		$connection->beginTransaction();
 		$connection->query('SELECT 1');
-		$this->assertFalse($wasAlreadyPublished);
+		Assert::assertFalse($wasAlreadyPublished);
 		$databaseTransactionProducer->publish('throw-away-message');
-		$this->assertFalse($wasAlreadyPublished);
+		Assert::assertFalse($wasAlreadyPublished);
 		$connection->rollBack();
-		$this->assertFalse($wasAlreadyPublished);
+		Assert::assertFalse($wasAlreadyPublished);
 
 		$databaseTransactionProducer->publish($message);
-		$this->assertTrue($wasAlreadyPublished);
+		Assert::assertTrue($wasAlreadyPublished);
 	}
 
 	private function getConnection(): Connection

--- a/tests/RabbitMq/Producer/ProducerCompilerPassTest.php
+++ b/tests/RabbitMq/Producer/ProducerCompilerPassTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace VasekPurchart\RabbitMqDatabaseTransactionProducerBundle\RabbitMq\Producer;
 
 use OldSound\RabbitMqBundle\RabbitMq\Producer;
+use PHPUnit\Framework\Assert;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -47,8 +48,8 @@ class ProducerCompilerPassTest extends \Matthias\SymfonyDependencyInjectionTest\
 		$originalProducerArgument = $this->container->findDefinition(
 			'old_sound_rabbit_mq.availability_generate_premise_producer'
 		)->getArgument(0);
-		$this->assertInstanceOf(Reference::class, $originalProducerArgument);
-		$this->assertSame(
+		Assert::assertInstanceOf(Reference::class, $originalProducerArgument);
+		Assert::assertSame(
 			'old_sound_rabbit_mq.availability_generate_premise_producer.original',
 			$originalProducerArgument->__toString()
 		);
@@ -60,8 +61,8 @@ class ProducerCompilerPassTest extends \Matthias\SymfonyDependencyInjectionTest\
 		$connectionArgument = $this->container->findDefinition(
 			'old_sound_rabbit_mq.availability_generate_premise_producer'
 		)->getArgument(1);
-		$this->assertInstanceOf(Reference::class, $connectionArgument);
-		$this->assertSame(
+		Assert::assertInstanceOf(Reference::class, $connectionArgument);
+		Assert::assertSame(
 			RabbitMqDatabaseTransactionProducerExtension::CONTAINER_SERVICE_DATABASE_CONNECTION,
 			$connectionArgument->__toString()
 		);


### PR DESCRIPTION
- [x] stop calling static methods in tests as non-static
- [x] use assertSame() where assertEquals() is not explicitly needed
- [x] use assertCount() after assertContains() for array comparison
- [x] add missing Assert::fail() in try+catch blocks when expecting exceptions
- [x] unify Assert::fail() message
- [x] replace Consistence\TestCase::ok() with expectNotToPerformAssertions()
- [x] use try+catch+fail when expecting exceptions with properties
- [x] rename data providers to singular where applicable
- [x] use DataProvider suffix for data providers
- [x] change data provider return type from array to Generator
- [x] declare data provider values on separate lines
- [x] isolate data provider cases using Closures
- [x] name data provider values
- [x] name data provider cases
- [x] extract multiple cases from test methods to data providers
- [x] remove unnecessary private methods for creating mocks